### PR TITLE
drm/panel: DEBIX DSI panels: stop overwriting the pwm-backlight brightness on every blank/unblank

### DIFF
--- a/drivers/gpu/drm/panel/panel-HC080IY28026-D60.c
+++ b/drivers/gpu/drm/panel/panel-HC080IY28026-D60.c
@@ -516,27 +516,11 @@ static int rad_panel_get_modes(struct drm_panel *panel,
 	return 1;
 }
 
-static int rad_bl_get_brightness(struct backlight_device *bl)
-{
-	struct mipi_dsi_device *dsi = bl_get_data(bl);
-	struct rad_panel *rad = mipi_dsi_get_drvdata(dsi);
-	u16 brightness;
-	int ret;
-
-	if (!rad->prepared)
-		return 0;
-
-	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
-
-	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
-	if (ret < 0)
-		return ret;
-
-	bl->props.brightness = brightness;
-
-	return brightness & 0xff;
-}
-static int delayBright = 1;
+/* #2026-09-01 rad_bl_get_brightness() removed: this panel answers the DCS
+ * "get display brightness" read with 0, and the op wrote that 0 back into
+ * bl->props.brightness, which is how the board came up at 12/255 and drifted
+ * to 0. Keep the cached props value instead.
+ */
 static int rad_bl_update_status(struct backlight_device *bl)
 {
 	struct mipi_dsi_device *dsi = bl_get_data(bl);
@@ -553,24 +537,20 @@ static int rad_bl_update_status(struct backlight_device *bl)
 	if (ret < 0)
 		return ret;
 
-	if (rad->backlight2) {
-		if(delayBright==1){
-			delayBright = 0;
-			msleep(1000);
-		}
-                rad->backlight2->props.power = FB_BLANK_UNBLANK;
-		
-		rad->backlight2->props.brightness = bl->props.brightness;
-                backlight_update_status(rad->backlight2);
-        }
-
+	/* #2026-09-01 do NOT copy this device's brightness into the pwm-backlight
+	 * (backlight2). rad_panel_enable()/disable() call backlight_enable() and
+	 * backlight_disable() on this device, so the copy ran on every panel
+	 * blank and unblank and overwrote whatever userspace (gsd-power) had set
+	 * on mipi_backlight - the "brightness resets after the screen sleeps"
+	 * bug. Power state for backlight2 is handled by the explicit
+	 * backlight_enable()/backlight_disable() calls in the panel ops.
+	 */
 
 	return 0;
 }
 
 static const struct backlight_ops rad_bl_ops = {
 	.update_status = rad_bl_update_status,
-	.get_brightness = rad_bl_get_brightness,
 };
 
 static const struct drm_panel_funcs rad_panel_funcs = {

--- a/drivers/gpu/drm/panel/panel-TD080B.c
+++ b/drivers/gpu/drm/panel/panel-TD080B.c
@@ -777,27 +777,11 @@ static int rad_panel_get_modes(struct drm_panel *panel,
 	return 1;
 }
 
-static int rad_bl_get_brightness(struct backlight_device *bl)
-{
-	struct mipi_dsi_device *dsi = bl_get_data(bl);
-	struct rad_panel *rad = mipi_dsi_get_drvdata(dsi);
-	u16 brightness;
-	int ret;
-
-	if (!rad->prepared)
-		return 0;
-
-	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
-
-	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
-	if (ret < 0)
-		return ret;
-
-	bl->props.brightness = brightness;
-
-	return brightness & 0xff;
-}
-static int delayBright = 1;
+/* #2026-09-01 rad_bl_get_brightness() removed: this panel answers the DCS
+ * "get display brightness" read with 0, and the op wrote that 0 back into
+ * bl->props.brightness, which is how the board came up at 12/255 and drifted
+ * to 0. Keep the cached props value instead.
+ */
 static int rad_bl_update_status(struct backlight_device *bl)
 {
 	struct mipi_dsi_device *dsi = bl_get_data(bl);
@@ -814,24 +798,20 @@ static int rad_bl_update_status(struct backlight_device *bl)
 	if (ret < 0)
 		return ret;
 
-	if (rad->backlight2) {
-		if(delayBright==1){
-			delayBright = 0;
-			msleep(1000);
-		}
-                rad->backlight2->props.power = FB_BLANK_UNBLANK;
-		
-		rad->backlight2->props.brightness = bl->props.brightness;
-                backlight_update_status(rad->backlight2);
-        }
-
+	/* #2026-09-01 do NOT copy this device's brightness into the pwm-backlight
+	 * (backlight2). rad_panel_enable()/disable() call backlight_enable() and
+	 * backlight_disable() on this device, so the copy ran on every panel
+	 * blank and unblank and overwrote whatever userspace (gsd-power) had set
+	 * on mipi_backlight - the "brightness resets after the screen sleeps"
+	 * bug. Power state for backlight2 is handled by the explicit
+	 * backlight_enable()/backlight_disable() calls in the panel ops.
+	 */
 
 	return 0;
 }
 
 static const struct backlight_ops rad_bl_ops = {
 	.update_status = rad_bl_update_status,
-	.get_brightness = rad_bl_get_brightness,
 };
 
 static const struct drm_panel_funcs rad_panel_funcs = {


### PR DESCRIPTION
Both DEBIX MIPI-DSI panel drivers overwrite the pwm-backlight's brightness on
every panel blank and unblank, so any brightness the user sets is lost as soon
as the screen sleeps and wakes.

## The bug

Two backlight devices exist on a DEBIX Model A with the HC080IY28026-D60 panel:

| device | driver | role |
|---|---|---|
| `mipi_backlight` | `pwm-backlight`, `default-brightness-level = <0xe6>` | drives the LEDs; this is the device userspace (`gsd-power`, `logind`) writes |
| `32e60000.mipi_dsi.0` | the panel driver's own DCS backlight | sets brightness over DCS **and copies its value into `mipi_backlight`** |

`rad_bl_update_status()` ends with:

```c
rad->backlight2->props.power = FB_BLANK_UNBLANK;
rad->backlight2->props.brightness = bl->props.brightness;
backlight_update_status(rad->backlight2);
```

`rad_panel_enable()` and `rad_panel_disable()` call `backlight_enable()` and
`backlight_disable()` on the DCS device, and both end up in
`update_status()` — so that copy runs on every blank and every unblank and
overwrites the value userspace set.

`rad_bl_get_brightness()` compounds it. The panel answers the DCS
"get display brightness" read with 0, and the op writes that 0 back into
`bl->props.brightness`, so the DCS device's cached value decays to 0. That is
also why the board comes up dim (12/255) after a reboot and can end up with a
lit panel and the backlight fully off.

## Reproduction

DEBIX Model A (2 GB), HC080IY28026-D60V.C panel, kernel 6.6.36 from
`lf_6.6.36-debix_model_a-b-infinity`, GNOME on Wayland. Set brightness to
204/255 from the desktop, then let the screen idle-dim, blank, and wake it:

```
12:03:39 set 204        mipi=204 pwr=0 dsi=180
12:04:02 idle-dim       mipi=78  pwr=0
12:04:33 blank          mipi=180 pwr=4      <- clobbered with the DCS device's value
12:05:02 gsd restores   mipi=204 pwr=4
12:05:03 unblank        mipi=180 pwr=0      <- clobbered again; the user's 204 is gone
```

(`mipi` = `/sys/class/backlight/mipi_backlight/brightness`, `dsi` = the DCS
device's, `pwr` = `bl_power`.) Note the ordering of the last two lines:
userspace restores brightness *before* the compositor unblanks, so the driver
always gets the last word — this cannot be worked around from userspace.

## The fix

Drop the `backlight2` copy and the `.get_brightness` op in both drivers. Power
for the pwm-backlight is still handled by the explicit
`backlight_enable()`/`backlight_disable()` calls in the panel ops; its
brightness is then owned by whoever writes the sysfs attribute.

Same run after the change, on the same board:

```
12:53:25 set 204        mipi=204 pwr=0 dsi=12
12:53:51 idle-dim       mipi=78  pwr=0
12:54:21 blank          mipi=78  pwr=4
12:54:48 gsd restores   mipi=204 pwr=4
12:54:49 unblank        mipi=204 pwr=0      <- holds
```

## Scope

- Patch 1 (`panel-HC080IY28026-D60.c`) is runtime-verified on the hardware.
- Patch 2 (`panel-TD080B.c`) is compile-tested only — I have no TD080B panel —
  but the removed code is byte-identical to patch 1's.
- The same code is in the other branches of this repo (5.10, 5.15, 6.1, 6.12
  copies of both drivers). Happy to send the same two patches against any of
  them if you tell me which branches you want them on.
